### PR TITLE
Bump dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject nubank/abracad "0.4.17"
   :description "De/serialize Clojure data structures with Avro."
-  :url "http://github.com/damballa/abracad"
+  :url "http://github.com/nubank/abracad"
   :licenses [{:name "Eclipse Public License"
               :url  "http://www.eclipse.org/legal/epl-v10.html"}
              {:name "Apache License, Version 2.0"

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,12 @@
              :clojure-1-9 {:dependencies
                            [[org.clojure/clojure "1.9.0"]
                             [midje "1.9.1" :exclusions [org.clojure/clojure]]
-                            [nubank/matcher-combinators "0.2.1"]]}}
+                            [nubank/matcher-combinators "0.2.1"]]}
+             :clojure-1-10 {:dependencies
+                           [[org.clojure/clojure "1.10.1"]
+                            [midje "1.9.9" :exclusions [org.clojure/clojure]]
+                            [org.xerial.snappy/snappy-java "1.1.7.3"]
+                            [nubank/matcher-combinators "1.2.1"]]}}
 
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]

--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
                            [[org.clojure/clojure "1.9.0"]
                             [midje "1.9.9" :exclusions [org.clojure/clojure]]
                             [org.xerial.snappy/snappy-java "1.1.7.3"]
-                            [nubank/matcher-combinators "1.2.1"]]
+                            [nubank/matcher-combinators "1.2.1"]]}
              :clojure-1-10 {:dependencies
                            [[org.clojure/clojure "1.10.1"]
                             [midje "1.9.9" :exclusions [org.clojure/clojure]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/abracad "0.4.16"
+(defproject nubank/abracad "0.4.17"
   :description "De/serialize Clojure data structures with Avro."
   :url "http://github.com/damballa/abracad"
   :licenses [{:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -30,20 +30,24 @@
             "loc"      ["vanity"]}
 
   :profiles {:dev         {:dependencies
-                           [[midje "1.9.1" :exclusions [org.clojure/clojure]]
-                            [nubank/matcher-combinators "0.2.1"]]}
+                           [[midje "1.9.9" :exclusions [org.clojure/clojure]]
+                            [org.xerial.snappy/snappy-java "1.1.7.3"]
+                            [nubank/matcher-combinators "1.2.1"]]}
              :clojure-1-7 {:dependencies
                            [[org.clojure/clojure "1.7.0"]
-                            [midje "1.9.1" :exclusions [org.clojure/clojure]]
+                            [midje "1.9.9" :exclusions [org.clojure/clojure]]
+                            [org.xerial.snappy/snappy-java "1.1.7.3"]
                             [nubank/matcher-combinators "0.2.1"]]}
              :clojure-1-8 {:dependencies
                            [[org.clojure/clojure "1.8.0"]
-                            [midje "1.9.1" :exclusions [org.clojure/clojure]]
+                            [midje "1.9.9" :exclusions [org.clojure/clojure]]
+                            [org.xerial.snappy/snappy-java "1.1.7.3"]
                             [nubank/matcher-combinators "0.2.1"]]}
              :clojure-1-9 {:dependencies
                            [[org.clojure/clojure "1.9.0"]
-                            [midje "1.9.1" :exclusions [org.clojure/clojure]]
-                            [nubank/matcher-combinators "0.2.1"]]}
+                            [midje "1.9.9" :exclusions [org.clojure/clojure]]
+                            [org.xerial.snappy/snappy-java "1.1.7.3"]
+                            [nubank/matcher-combinators "1.2.1"]]
              :clojure-1-10 {:dependencies
                            [[org.clojure/clojure "1.10.1"]
                             [midje "1.9.9" :exclusions [org.clojure/clojure]]

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,9 @@
              {:name "Apache License, Version 2.0"
               :url  "http://www.apache.org/licenses/LICENSE-2.0.html"}]
 
-  :plugins [[codox/codox "0.6.4"]
+  :plugins [[codox/codox "0.10.7"]
             [lein-midje "3.2.1"]
-            [lein-cloverage "1.0.10"]
+            [lein-cloverage "1.1.2"]
             [lein-vanity "0.2.0"]]
 
   :repositories [["central" {:url "https://repo1.maven.org/maven2/" :snapshots false}]
@@ -16,15 +16,15 @@
 
   :global-vars {*warn-on-reflection* true}
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.apache.avro/avro "1.8.2"]
-                 [cheshire/cheshire "5.6.1"]]
+  :dependencies [[org.apache.avro/avro "1.9.1"]
+                 [cheshire/cheshire "5.9.0"]]
 
   :codox {:include [abracad.avro abracad.avro.edn]}
 
   :aliases {"test-all" ["with-profile" ~(str "clojure-1-7:"
                                              "clojure-1-8:"
-                                             "clojure-1-9")
+                                             "clojure-1-9:"
+                                             "clojure-1-10")
                         "midje"]
             "coverage" ["cloverage" "-s" "coverage"]
             "loc"      ["vanity"]}


### PR DESCRIPTION
Two CVEs are indirectly related to abracad through `avro` -> `commons-compress`:
https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-72275
https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-32473

This also ensures tests run for `clojure-1.10` and doesn't force `clojure` as a dependency of this library so newer versions won't pull `clojure-1.9`.

Feel free to drop any of the changes other than bumping avro (and cheshire).

Thanks,
Henry Kupty