### PR TITLE
Bumping avro due to security issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
 
   :global-vars {*warn-on-reflection* true}
 
-  :dependencies [[org.apache.avro/avro "1.9.1"]
+  :dependencies [[org.apache.avro/avro "1.10.1"]
                  [cheshire/cheshire "5.9.0"]]
 
   :codox {:include [abracad.avro abracad.avro.edn]}


### PR DESCRIPTION
According to dependency-check, avro uses jackson-databind and is susceptible to the following vulnerabilities:

- CVE-2019-14540
- CVE-2019-14892
- CVE-2019-14893
- CVE-2019-16335
- CVE-2019-16942
- CVE-2019-16943
- CVE-2019-17267
- CVE-2019-17531
- CVE-2019-20330
- CVE-2020-10672
- CVE-2020-10673
- CVE-2020-10968
- CVE-2020-10969
- CVE-2020-11111
- CVE-2020-11112
- CVE-2020-11113
- CVE-2020-11619
- CVE-2020-11620
- CVE-2020-14060
- CVE-2020-14061
- CVE-2020-14062
- CVE-2020-14195
- CVE-2020-24616
- CVE-2020-24750
- CVE-2020-25649
- CVE-2020-8840
- CVE-2020-9546
- CVE-2020-9547
- CVE-2020-9548

This bump will fix these security issues.